### PR TITLE
implement initial mcp server as a stdio server

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ Make sure you have the following installed:
 - Python 3.6+
 - uv
 - pre-commit
+- just

--- a/justfile
+++ b/justfile
@@ -1,0 +1,9 @@
+test: 
+    uv run pytest --cov=src
+
+check: 
+    pre-commit run -a
+
+run:
+    uv sync
+    uv run cli

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,6 @@ dependencies = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.mypy]
-files = ["src", "tests"]
-strict = true
-disable_error_code = ["import-untyped"]
-
 [mypy-mcp.tool]
 ignore_errors = true
 
@@ -27,7 +22,23 @@ dev = [
     "docformatter>=1.7.5",
     "mypy==1.15.0",
     "pytest>=8.3.4",
+    "pytest-asyncio>=0.25.3",
     "pytest-cov>=6.0.0",
+    "pytest-mock>=3.14.0",
     "ruff==0.9.7",
 ]
 
+[project.scripts]
+cli = "notion_mcp.cli:run_main"
+
+[tool.mypy]
+files = ["src", "tests"]
+strict = true
+disable_error_code = ["import-untyped"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+
+[tool.coverage.run]
+concurrency = ["thread"]

--- a/src/notion_mcp/__init__.py
+++ b/src/notion_mcp/__init__.py
@@ -1,2 +1,1 @@
-def hello() -> str:
-    return "Hello from notion-mcp!"
+from .cli import run_main  # noqa: F401

--- a/src/notion_mcp/cli.py
+++ b/src/notion_mcp/cli.py
@@ -1,23 +1,26 @@
-# server.py
-from mcp.server.fastmcp import FastMCP
+import asyncio
+import mcp.types as types
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
 
-# Create an MCP server
-mcp = FastMCP("Demo")
-
-
-# Add an addition tool
-@mcp.tool()  # type: ignore
-def add(a: int, b: int) -> int:
-    """
-    Add two numbers.
-    """
-    return a + b
+app = Server("example-server")
 
 
-# Add a dynamic greeting resource
-@mcp.resource("greeting://{name}")  # type: ignore
-def get_greeting(name: str) -> str:
-    """
-    Get a personalized greeting.
-    """
-    return f"Hello, {name}!"
+@app.list_resources()  # type: ignore
+async def list_resources() -> list[types.Resource]:
+    return [types.Resource(uri="example://resource", name="Example Resource")]
+
+
+# pragma: no cover
+async def main() -> None:
+    async with stdio_server() as streams:
+        await app.run(streams[0], streams[1], app.create_initialization_options())
+
+
+# pragma: no cover
+def run_main() -> None:
+    asyncio.run(main())
+
+
+if __name__ == "__main__":
+    run_main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,8 @@
-from notion_mcp.cli import add
+import pytest
+from notion_mcp.cli import list_resources
 
 
-def test_add() -> None:
-    assert add(1, 2) == 3
+@pytest.mark.asyncio  # type: ignore
+async def test_list_resources() -> None:
+    result = await list_resources()
+    assert len(result) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -390,7 +390,9 @@ dev = [
     { name = "docformatter" },
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-mock" },
     { name = "ruff" },
 ]
 
@@ -403,7 +405,9 @@ dev = [
     { name = "docformatter", specifier = ">=1.7.5" },
     { name = "mypy", specifier = "==1.15.0" },
     { name = "pytest", specifier = ">=8.3.4" },
+    { name = "pytest-asyncio", specifier = ">=0.25.3" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "ruff", specifier = "==0.9.7" },
 ]
 
@@ -566,6 +570,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.25.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/a8/ecbc8ede70921dd2f544ab1cadd3ff3bf842af27f87bbdea774c7baa1d38/pytest_asyncio-0.25.3.tar.gz", hash = "sha256:fc1da2cf9f125ada7e710b4ddad05518d4cee187ae9412e9ac9271003497f07a", size = 54239 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/17/3493c5624e48fd97156ebaec380dcaafee9506d7e2c46218ceebbb57d7de/pytest_asyncio-0.25.3-py3-none-any.whl", hash = "sha256:9e89518e0f9bd08928f97a3482fdc4e244df17529460bc038291ccaf8f85c7c3", size = 19467 },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -576,6 +592,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/be/45/9b538de8cef30e17c7b45ef42f538a94889ed6a16f2387a6c89e73220651/pytest-cov-6.0.0.tar.gz", hash = "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0", size = 66945 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/36/3b/48e79f2cd6a61dbbd4807b4ed46cb564b4fd50a76166b1c4ea5c1d9e2371/pytest_cov-6.0.0-py3-none-any.whl", hash = "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35", size = 22949 },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/90/a955c3ab35ccd41ad4de556596fa86685bf4fc5ffcc62d22d856cfd4e29a/pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0", size = 32814 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/3b/b26f90f74e2986a82df6e7ac7e319b8ea7ccece1caec9f8ab6104dc70603/pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f", size = 9863 },
 ]
 
 [[package]]


### PR DESCRIPTION
- add just command for efficiency 
- implement cli command to launch mcp server as a stdio server
- fix pytest setting 
- remove sample implments
- add unittest